### PR TITLE
Replace bootstrap <button> with identically styled <a> hyperlinks

### DIFF
--- a/OpenTabletDriver.Web/Views/Plugins/Index.cshtml
+++ b/OpenTabletDriver.Web/Views/Plugins/Index.cshtml
@@ -46,21 +46,21 @@
                         </div>
                     </div>
                     <div class="mt-auto text-center">
-                        <button type="button" class="btn-sm btn-primary me-1"
+                        <a role="button" class="btn-sm btn-primary me-1"
                                 @(string.IsNullOrWhiteSpace(metadata.DownloadUrl) ? "disabled" : string.Empty)
-                                onclick="location.href='@metadata.DownloadUrl'">
+                                href="@metadata.DownloadUrl">
                             Download
-                        </button>
-                        <button type="button" class="btn-sm btn-info me-1"
+                        </a>
+                        <a role="button" class="btn-sm btn-info me-1"
                                 @(string.IsNullOrWhiteSpace(metadata.RepositoryUrl) ? "disabled" : string.Empty)
-                                onclick="location.href='@metadata.WikiUrl'">
+                                href="@metadata.WikiUrl">
                             Wiki
-                        </button>
-                        <button type="button" class="btn-sm btn-info"
+                        </a>
+                        <a role="button" class="btn-sm btn-info"
                                 @(string.IsNullOrWhiteSpace(metadata.RepositoryUrl) ? "disabled" : string.Empty)
-                                onclick="location.href='@metadata.RepositoryUrl'">
+                                href="@metadata.RepositoryUrl">
                             Source
-                        </button>
+                        </a>
                     </div>
                 </div>
             </div>

--- a/OpenTabletDriver.Web/Views/Shared/Release/_ReleaseCard.cshtml
+++ b/OpenTabletDriver.Web/Views/Shared/Release/_ReleaseCard.cshtml
@@ -17,7 +17,7 @@
     <li class="list-group-item text-center @border">
         <img class="p-1" width="250" style="@(isPrimary ? string.Empty : "opacity:0.4")" src="otd.png"/>
         <div class="mt-1 mb-1">
-            <button class="btn @buttonColor" onclick="location.href='@Model.Url'">View On GitHub</button>
+            <a role="button" class="btn @buttonColor" href="@Model.Url">View On GitHub</a>
         </div>
     </li>
     @foreach (IReleaseAsset asset in await Model.GetReleaseAssets())


### PR DESCRIPTION
Makes the buttons act like regular links, using the same bootstrap style stuff as the bootstrap buttons. The URL can be previewed, middle-clicking with mouse opens in new tab, etc etc.