### PR TITLE
Add Administrator account warning on Window FAQ.

### DIFF
--- a/OpenTabletDriver.Web/Views/Wiki/FAQ/Windows.cshtml
+++ b/OpenTabletDriver.Web/Views/Wiki/FAQ/Windows.cshtml
@@ -56,3 +56,25 @@
         <li>Move the shortcut into the folder that opened.</li>
     </ol>
 </div>
+
+<hr/>
+
+<h3 class="wiki-nav-item pb-3" id="uac">
+    OpenTabletDriver gives an Administrator warning
+</h3>
+<div class="ms-3">
+    <p>
+        When Starting OpenTabletDriver you may get an error warning you about Administrator Permissions. OpenTabletDriver 
+        shouldn't be run as Administrator. This causes the plugin manager, FAQ page and Tablet debugger to not work along with 
+        other features.
+    </p>
+    <ol>
+        <li>Press the Windows key and search<code> User Account Control</code>.</li>
+        <li>Move the slider to one of the top 2 options.</li>
+        <li>Click OK, then restart your computer.</li>
+    </ol>
+        <p>
+        If this does not solve the issue, check that you are not using the "Administrator" named account as it overrides User Account
+        Control.
+    </p>
+</div>

--- a/OpenTabletDriver.Web/Views/Wiki/FAQ/Windows.cshtml
+++ b/OpenTabletDriver.Web/Views/Wiki/FAQ/Windows.cshtml
@@ -59,7 +59,7 @@
 
 <hr/>
 
-<h3 class="wiki-nav-item pb-3" id="uac">
+<h3 class="wiki-nav-item pb-2" id="uac">
     OpenTabletDriver gives an Administrator warning
 </h3>
 <div class="ms-3">
@@ -73,7 +73,7 @@
         <li>Move the slider to one of the top 2 options.</li>
         <li>Click OK, then restart your computer.</li>
     </ol>
-        <p>
+    <p>
         If this does not solve the issue, check that you are not using the "Administrator" named account as it overrides User Account
         Control.
     </p>


### PR DESCRIPTION
Add an Administrator account FAQ instance showing how to turn on uac.

Should an override for the warning by running OpenTabletDriver under another user be added as it is quite long as i don't know if to add the override?

Should be enough to close #21 though another line into the UAC warning may need to be added on startup on OpenTabletDriver, and the override may need to be listed.