### PR TITLE
add GDM notice

### DIFF
--- a/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
+++ b/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
@@ -41,6 +41,7 @@
             </codeblock>
         </li>
     </ol>
+    GDM handles graphics tablets differently and takes over the socket that OpenTabletDriver uses, so you need to switch to an another display manager.
 </div>
 <div class="ms-3">
     <h3>


### PR DESCRIPTION
Self explanatory. GDM just doesn't like other apps using the graphics tablet.