### PR TITLE
Add model identifier hint box to tablet overview

### DIFF
--- a/OpenTabletDriver.Web/Views/Tablets/Index.cshtml
+++ b/OpenTabletDriver.Web/Views/Tablets/Index.cshtml
@@ -5,6 +5,13 @@
 @model ContentSearchViewModel
 
 <div class="container">
+    <div class="card mb-4">
+        <div class="card-body d-flex flex-sm-row flex-column">
+            As there are many different revisions of tablets out there, you will need its model identifier to check compatibility with OpenTabletDriver.
+            <br/>
+            Usually, this value can be found either below the tablet itself or on the box it came in.
+        </div>
+    </div>
     <div class="form-floating mb-3">
         <input id="searchInput" type="text" class="form-control" onkeyup="searchInput()" placeholder="Search"
                value="@Model.Search"/>

--- a/OpenTabletDriver.Web/Views/Tablets/Index.cshtml
+++ b/OpenTabletDriver.Web/Views/Tablets/Index.cshtml
@@ -9,7 +9,7 @@
         <div class="card-body d-flex flex-sm-row flex-column">
             As there are many different revisions of tablets out there, you will need its model identifier to check compatibility with OpenTabletDriver.
             <br/>
-            Usually, this value can be found either below the tablet itself or on the box it came in.
+            Usually, this value can be found either on the back of the tablet itself or on the box it came in.
         </div>
     </div>
     <div class="form-floating mb-3">


### PR DESCRIPTION
As discussed on discord, this might help non-tech-savy people better understand the overview page.

See: https://discord.com/channels/615607687467761684/866089826075672586/945760732786622564