### PR TITLE
Fix incorrect wayland session detection faq

### DIFF
--- a/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
+++ b/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
@@ -226,7 +226,8 @@
                 Add this block below the first 2 lines of the file, then save and exit
                 <codeblock class="mt-2" language="ini">
                     [Service]
-                    Environment=WAYLAND_DISPLAY=:0
+                    ExecStart=
+                    ExecStart=/bin/bash -c "WAYLAND_DISPLAY=$WAYLAND_DISPLAY /usr/bin/otd"
                 </codeblock>
             </li>
             <li>


### PR DESCRIPTION
The current suggested fix doesn't work as I believe `:0` is a X11 thing. For wayland it should be `wayland-0` (or a number other than 0).

I've used `ExecStart` instead of `Environment` because that's the only way to get systemd to expand the variable.