### PR TITLE
fix: broken repo link

### DIFF
--- a/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
+++ b/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
@@ -9,7 +9,7 @@
     <p>
         This occurs because another program is reading the tablet at the same time as OpenTabletDriver.
         <small>
-            <a class="link-light" href="https://github.com/InfinityGhost/OpenTabletDriver/issues/68">#68</a>
+            <a class="link-light" href="https://github.com/OpenTabletDriver/OpenTabletDriver/issues/68">#68</a>
         </small>
         <ol>
             <li>


### PR DESCRIPTION
Says "InfinityGhost" instead of "OpenTabletDriver". I guess it was written before this repo moved to the organization.