### PR TITLE
Linux FAQ: Add missing 'sudo' prefix to command

### DIFF
--- a/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
+++ b/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
@@ -113,7 +113,7 @@
     <codeblock class="mt-2" language="sh">
         sudo udevadm control --reload-rules
         # Skips the step requiring a replug of the tablet.
-        udevadm trigger
+        sudo udevadm trigger
         # Helps ensure that OpenTabletDriver uses the tablet correctly.
         systemctl --user restart opentabletdriver
     </codeblock>


### PR DESCRIPTION
The command must be run as root, so the current fix does not work as a copy-paste.