### PR TITLE
Integrate highlight.js syntax highlighting

### DIFF
--- a/OpenTabletDriver.Web/TagHelpers/CodeBlockTagHelper.cs
+++ b/OpenTabletDriver.Web/TagHelpers/CodeBlockTagHelper.cs
@@ -1,131 +1,59 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO.Pipes;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.CodeAnalysis;
 
 namespace OpenTabletDriver.Web.TagHelpers
 {
     [HtmlTargetElement("codeblock")]
     public class CodeBlockTagHelper : TagHelper
     {
-        public string Language { set; get; }
-        
+        public string Language { set; get; } = "plaintext";
+
         public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             output.TagName = "pre";
+            var defaultClasses = "card";
 
             if (output.Attributes.TryGetAttribute("class", out var classAttr))
-                output.Attributes.SetAttribute("class", $"{classAttr.Value} card card-body");
+                output.Attributes.SetAttribute("class", $"{classAttr.Value} {defaultClasses}");
             else
-                output.Attributes.Add("class", $"card card-body");
+                output.Attributes.Add("class", defaultClasses);
 
-
-            var content = await output.GetChildContentAsync();
-            var innerHtml = content.GetContent().Trim('\n');
-
-            var body = TrimPreceding(innerHtml, ' ');
-            output.Content.SetHtmlContent(body);
+            var rawContent = (await output.GetChildContentAsync()).GetContent();
+            var innerHTML = $"<code class='language-{Language}'>{TrimBaseIndentation(rawContent)}\n</code>";
+            output.Content.SetHtmlContent(innerHTML);
         }
 
-        private string TrimPreceding(string value, char character)
+        private string TrimBaseIndentation(string content)
         {
-            var lines = value.Split(Environment.NewLine);
-            int preceding = CountPreceding(lines, character);
-            var trimmedLines = from line in lines
-                select TrimPrecedingLine(line, character, preceding);
+            var endsTrimmedContent = content.TrimStart('\n').TrimEnd();
+            var lines = endsTrimmedContent.Split(Environment.NewLine);
+            var baseIndentationLength = CountIndentation(lines[0]);
 
-            var formattedLines = LanguageFormat(trimmedLines.ToArray(), Language);
-
-            return string.Join(Environment.NewLine, formattedLines);
-        }
-
-        private IEnumerable<string> LanguageFormat(IList<string> lines, string language)
-        {
-            switch (language)
+            for (int i = 0; i != lines.Length; i++)
             {
-                case "sh":
-                case "bash":
-                case "nix":
+                var line = lines[i];
+
+                var indentationLength = CountIndentation(line);
+                if (indentationLength < baseIndentationLength)
                 {
-                    for (int i = 0; i < lines.Count; i++)
+                    if (indentationLength == line.Length)
                     {
-                        var line = lines[i];
-                        if (line.TrimStart().StartsWith("#"))
-                        {
-                            var nextLine = lines[i + 1];
-                            const string tag = "span";
-                            yield return $"<{tag} class=\"text-muted\">{line}{Environment.NewLine}</{tag}>{nextLine}";
-                            i++;
-                        }
-                        else
-                        {
-                            yield return line;
-                        }
+                        lines[i] = "";
+                        continue;
                     }
 
-                    break;
-                }
-                case "ini":
-                {
-                    for (int i = 0; i < lines.Count; i++)
-                    {
-                        var line = lines[i];
-                        if (Regex.IsMatch(line, @"^\[.+?\]$"))
-                        {
-                            var nextLine = lines[i + 1];
-                            const string tag = "span";
-                            yield return $"<{tag} class=\"text-info\">{line}{Environment.NewLine}</{tag}>{nextLine}";
-                            i++;
-                        }
-                        else
-                        {
-                            yield return line;
-                        }
-                    }
-
-                    break;
-                }
-                default:
-                {
-                    foreach (var line in lines)
-                        yield return line;
-                    break;
-                }
-            }
-        }
-
-        private int CountPreceding(IEnumerable<string> lines, char leadingCharacter)
-        {
-            foreach (var line in lines)
-            {
-                // Make sure that the line actually starts with the leading character
-                if (line.StartsWith(leadingCharacter) == false)
-                    continue;
-
-                // Determine last index of leading character, return if something else is found
-                for (var i = 0; i < line.Length; i++)
-                {
-                    var character = line[i];
-                    if (character != leadingCharacter)
-                        return i;
+                    return new Regex("^\\s*\n(\\s*)(?=\\S*)").Replace(endsTrimmedContent, "$1", 1);
                 }
 
-                // Assume that this line is the template for trimming
-                return line.Length;
+                lines[i] = line.Substring(Math.Min(baseIndentationLength, line.Length));
             }
 
-            throw new ArgumentException("No lines match the target leading character.", nameof(lines));
+            return String.Join(Environment.NewLine, lines).Trim();
         }
 
-        private string TrimPrecedingLine(string line, char character, int amount)
-        {
-            return line.StartsWith(character) ? new string(line.Skip(amount).ToArray()) : line;
-        }
+        private int CountIndentation(string line) => line.TakeWhile(Char.IsWhiteSpace).Count();
     }
 }

--- a/OpenTabletDriver.Web/Views/Shared/_Scripts.cshtml
+++ b/OpenTabletDriver.Web/Views/Shared/_Scripts.cshtml
@@ -1,3 +1,5 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.5.1/build/highlight.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.5.1/build/languages/nix.min.js" crossorigin="anonymous"></script>
 <script src="~/js/site.js" asp-append-version="true"></script>

--- a/OpenTabletDriver.Web/Views/Shared/_Styles.cshtml
+++ b/OpenTabletDriver.Web/Views/Shared/_Styles.cshtml
@@ -1,3 +1,4 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.0.2/dist/darkly/bootstrap.min.css"
       integrity="sha256-IzD7YgcFC7mrH3sadY/G75Gc49OgfS5IVOgFlxtdoUI=" crossorigin="anonymous"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.5.1/build/styles/nnfx-dark.min.css" crossorigin="anonymous">
 <link rel="stylesheet" href="~/css/site.css"/>

--- a/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
+++ b/OpenTabletDriver.Web/Views/Wiki/FAQ/Linux.cshtml
@@ -14,7 +14,7 @@
         <ol>
             <li>
                 Perform the following commands in a terminal
-                <codeblock class="mt-2">
+                <codeblock class="mt-2" language="sh">
                     echo "blacklist wacom" | sudo tee -a /etc/modprobe.d/blacklist.conf
                     sudo rmmod wacom
                 </codeblock>
@@ -77,7 +77,7 @@
         <br/>
         If you installed OpenTabletDriver via your package manager,
         you may need to run the following command then replug your tablet.
-        <codeblock class="mt-2">
+        <codeblock class="mt-2" language="sh">
             sudo udevadm control --reload-rules
         </codeblock>
     </p>
@@ -154,7 +154,7 @@
     <ol>
         <li>Make sure you set the <code>SDL_VIDEODRIVER</code> to <code>wayland</code>.</li>
     </ol>
-    <codeblock language="sh">
+    <codeblock class="mt-2" language="sh">
         # Export the environment variable
         export SDL_VIDEODRIVER=wayland
         # Start osu! lazer via the AppImage assuming its in the working directory

--- a/OpenTabletDriver.Web/wwwroot/css/site.css
+++ b/OpenTabletDriver.Web/wwwroot/css/site.css
@@ -69,3 +69,13 @@ body {
   white-space: nowrap;
   line-height: 60px; /* Vertically center the text there */
 }
+
+/* Highlight.js Overrides
+-------------------------------------------------- */
+.hljs {
+  background: inherit;
+}
+
+pre code.hljs {
+  padding: 1rem;
+}

--- a/OpenTabletDriver.Web/wwwroot/js/site.js
+++ b/OpenTabletDriver.Web/wwwroot/js/site.js
@@ -24,3 +24,6 @@ function ajaxGet(url, data, callback) {
     xhr.open('GET', url);
     xhr.send(data);
 }
+
+// highlight.js - do syntax highlighting on all elements with selector `pre code`
+hljs.highlightAll();


### PR DESCRIPTION
## Changes

- Refactor/rewrite the `codeblock` tag helper to play well with highlight.js
- Add CDN sources for highlight.js
- Override some highlight.js defaults to maintain the existing visuals
- Complete missing attributes on a few codeblocks

I played around *a lot* with the indentation trimming implementation of the tag helper.
I think its current state looks sensible:

- Lines are trimmed with the first line's indentation considered as the base.
- If any non-blank line has less indentation than the base indentation, it gives up on trimming contents since that's an irrecoverable violation. 
  So instead, blank lines are trimmed from the ends of the full contents, the internals are left as is.

Also, there is no performance impact at all to calling `highlightAll` on all pages, since [all it does](https://github.com/highlightjs/highlight.js/blob/main/src/highlight.js#L795-L807) is check for the existence of a `pre code` selector.