### PR TITLE
remove layman commands from gentoo installation

### DIFF
--- a/OpenTabletDriver.Web/Views/Wiki/Install/Linux.cshtml
+++ b/OpenTabletDriver.Web/Views/Wiki/Install/Linux.cshtml
@@ -97,11 +97,6 @@
             This is only required if you don't already have the Guru overlay configured
         </small>
         <codeblock class="mt-2" language="bash">
-            # Add guru repository
-            sudo layman -L
-            sudo layman -a guru
-            sudo layman -s guru
-
             # Enable guru repository
             sudo eselect repository enable guru
             sudo emerge --sync guru


### PR DESCRIPTION
per [gentoo wiki](https://wiki.gentoo.org/wiki/Layman), layman is no longer recommended. `eselect repository` on its own is recommended.